### PR TITLE
Allow authing against local users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ to enable context processor add `django_ory_auth.context.processor` to the `cont
 
 ## Optimisation
 
-This library will cache authentication requests and logout URLs if a [caching backend](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-CACHES) is enabled.
+This library will cache authentication requests and logout URLs if a [caching backend](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-CACHES) is enabled.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ The package provides context processor to provide the following urls
 - profile_url (available for authenticated users)
 
 to enable context processor add `django_ory_auth.context.processor` to the `context_processor` setting
+
+## Optimisation
+
+This library will cache authentication requests and logout URLs if a [caching backend](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-CACHES) is enabled.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Last step is to add `django_ory_auth.middleware.AuthenticationMiddleware` under 
 
 MIDDLEWARE = [
     …
+    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django_ory_auth.middleware.AuthenticationMiddleware",
     ...

--- a/README.md
+++ b/README.md
@@ -81,3 +81,18 @@ to enable context processor add `django_ory_auth.context.processor` to the `cont
 ## Optimisation
 
 This library will cache authentication requests and logout URLs if a [caching backend](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-CACHES) is enabled.
+
+To make sure caches get cleared on logout include urls:
+
+```
+import django_ory_auth.urls
+
+urlpatterns = [
+    ...
+    path("ory/", include(django_ory_auth.urls))
+]
+```
+
+In the Ory console, go to "Account experience" and set the right URL in the "Post-logout redirect" to e.g. `https://<your domain>/ory/_logout`
+
+Now when someone logs out, Ory will redirect to a view that clears the cached auth data in Django, and will then redirect them to the index page.

--- a/django_ory_auth/apps.py
+++ b/django_ory_auth/apps.py
@@ -10,4 +10,6 @@ def config():
     return {
         'ORY_SDK_URL': getattr(settings, 'ORY_SDK_URL', 'http://127.0.0.1:4433'),
         'ORY_UI_URL': getattr(settings, 'ORY_UI_URL', 'http://127.0.0.1:4455'),
+        # seconds to cache auth info for
+        'ORY_AUTH_REFRESH_INTERVAL': getattr(settings, 'ORY_AUTH_REFRESH_INTERVAL', 300),
     }

--- a/django_ory_auth/apps.py
+++ b/django_ory_auth/apps.py
@@ -10,5 +10,4 @@ def config():
     return {
         'ORY_SDK_URL': getattr(settings, 'ORY_SDK_URL', 'http://127.0.0.1:4433'),
         'ORY_UI_URL': getattr(settings, 'ORY_UI_URL', 'http://127.0.0.1:4455'),
-        'LOGOUT_REDIRECT_URL': getattr(settings, 'LOGOUT_REDIRECT_URL', '/'),
     }

--- a/django_ory_auth/apps.py
+++ b/django_ory_auth/apps.py
@@ -10,4 +10,5 @@ def config():
     return {
         'ORY_SDK_URL': getattr(settings, 'ORY_SDK_URL', 'http://127.0.0.1:4433'),
         'ORY_UI_URL': getattr(settings, 'ORY_UI_URL', 'http://127.0.0.1:4455'),
+        'LOGOUT_REDIRECT_URL': getattr(settings, 'LOGOUT_REDIRECT_URL', '/'),
     }

--- a/django_ory_auth/backend.py
+++ b/django_ory_auth/backend.py
@@ -3,6 +3,7 @@ import requests
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.contrib.auth.backends import BaseBackend
+from django.core.cache import cache
 from .apps import config
 
 UserModel = get_user_model()

--- a/django_ory_auth/backend.py
+++ b/django_ory_auth/backend.py
@@ -1,9 +1,7 @@
 import requests
 
 from django.contrib.auth import get_user_model
-from django.conf import settings
 from django.contrib.auth.backends import BaseBackend
-from django.core.cache import cache
 from .apps import config
 
 UserModel = get_user_model()
@@ -11,27 +9,52 @@ HTTP_STATUS_OK = 200
 HTTP_STATUS_UNAUTHORIZED = 401
 
 class OryBackend(BaseBackend):
+    def _fetch_remote_session(self, request):
+        """
+        Network call to get the remote user session.
+        :param request:
+        :return:
+        """
+        sdk_url = config().get('ORY_SDK_URL')
+        sess = requests.get(
+            f"{sdk_url}/sessions/whoami",
+            cookies=request.COOKIES
+        )
+        if sess.status_code != HTTP_STATUS_OK:
+            return {}
+        return sess.json() or {}
+
+    def _fetch_logout_url(self, request):
+        """
+        Make a network request for the logout URL
+        :param request:
+        :return:
+        """
+        r = requests.get(
+            f"{config().get('ORY_SDK_URL')}/self-service/logout/browser",
+            cookies=request.COOKIES
+        )
+        return r.json().get('logout_url')
+
     def authenticate(self, request):
-        cache_key = f"userid_{request.COOKIES.get('sessionid')}"
-        user_id = cache.get(cache_key)
-        if not user_id:
-            sdk_url = config().get('ORY_SDK_URL')
-            sess = requests.get(
-                f"{sdk_url}/sessions/whoami",
-                cookies=request.COOKIES
-            )
-            if sess.status_code != HTTP_STATUS_OK:
-                return None
-            user_id = sess.json().get('identity', {}).get('id', None)
-            if user_id:
-                cache.set(cache_key, user_id, timeout=300) # Cache for 5 minutes
-        
+        """
+        Validate the user remotely and return a user, creating it if
+        it doesn't exist on our side.
+        :param request:
+        :return: User
+        """
+        remote_session = self._fetch_remote_session(request)
+        user_id = remote_session.get('identity', {}).get('id', None)
+
         if not user_id:
             return None
-            
-        user, created = UserModel._default_manager.get_or_create(
+
+        user, _ = UserModel._default_manager.get_or_create(
             **{UserModel.USERNAME_FIELD: user_id}
         )
 
-        return user
+        logout_url = self._fetch_logout_url(request)
+        user.ory_logout_url = logout_url
 
+        user.backend = self
+        return user

--- a/django_ory_auth/backend.py
+++ b/django_ory_auth/backend.py
@@ -11,16 +11,23 @@ HTTP_STATUS_UNAUTHORIZED = 401
 
 class OryBackend(BaseBackend):
     def authenticate(self, request):
-        sdk_url = config().get('ORY_SDK_URL')
-        sess = requests.get(
-            f"{sdk_url}/sessions/whoami",
-            cookies=request.COOKIES
-        )
-        if sess.status_code != HTTP_STATUS_OK:
-            return None
-        user_id = sess.json().get('identity', {}).get('id', None)
+        cache_key = f"userid_{request.COOKIES.get('sessionid')}"
+        user_id = cache.get(cache_key)
+        if not user_id:
+            sdk_url = config().get('ORY_SDK_URL')
+            sess = requests.get(
+                f"{sdk_url}/sessions/whoami",
+                cookies=request.COOKIES
+            )
+            if sess.status_code != HTTP_STATUS_OK:
+                return None
+            user_id = sess.json().get('identity', {}).get('id', None)
+            if user_id:
+                cache.set(cache_key, user_id, timeout=300) # Cache for 5 minutes
+        
         if not user_id:
             return None
+            
         user, created = UserModel._default_manager.get_or_create(
             **{UserModel.USERNAME_FIELD: user_id}
         )

--- a/django_ory_auth/context.py
+++ b/django_ory_auth/context.py
@@ -1,30 +1,20 @@
-import requests
 from django.conf import settings
-from django.core.cache import cache
 
 def processor(request):
+    logout_url = ""
+
+    if request.user.is_authenticated:
+        if hasattr(request.user, "ory_logout_url"):
+            logout_url = request.user.ory_logout_url
+
     context = {
         'login_url': f"{settings.ORY_UI_URL}/login",
         'signup_url': f"{settings.ORY_UI_URL}/registration",
-        'logout_url': "",
+        'logout_url': logout_url,
         'recovery_url': f"{settings.ORY_UI_URL}/recovery",
         'verify_url': f"{settings.ORY_UI_URL}/verification",
         'profile_url': f"{settings.ORY_UI_URL}/settings",
     }
-    # Only make this request for users authenticated via Ory. 
-    # Local users will have the email field set, but not users in Ory
-    if request.user.is_authenticated and not request.user.email:
-        cache_key = f"logout_{request.COOKIES.get('sessionid')}"
-        logout_url = cache.get(cache_key)
-        if not logout_url:
-            r = requests.get(
-                f"{settings.ORY_SDK_URL}/self-service/logout/browser",
-                cookies=request.COOKIES
-            )
-            logout_url = r.json().get('logout_url')
-            cache.set(cache_key, logout_url, timeout=900) # Cache for 15 minutes
-
-        context["logout_url"] = logout_url
 
     return context
 

--- a/django_ory_auth/context.py
+++ b/django_ory_auth/context.py
@@ -1,5 +1,3 @@
-from json import JSONDecodeError
-
 import requests
 from django.conf import settings
 
@@ -13,16 +11,15 @@ def processor(request):
         'verify_url': f"{settings.ORY_UI_URL}/verification",
         'profile_url': f"{settings.ORY_UI_URL}/settings",
     }
-    if request.user.is_authenticated:
+    # Only make this request for users authenticated via Ory. 
+    # Local users will have the email field set, but not users in Ory
+    if request.user.is_authenticated and not request.user.email:
         r = requests.get(
             f"{settings.ORY_SDK_URL}/self-service/logout/browser",
             cookies=request.COOKIES
         )
 
-        try:
-            context["logout_url"] = r.json().get('logout_url')
-        except JSONDecodeError:
-            # This will fail for local users, so don't bomb out
-            pass
+        context["logout_url"] = r.json().get('logout_url')
+
     return context
 

--- a/django_ory_auth/context.py
+++ b/django_ory_auth/context.py
@@ -1,6 +1,6 @@
 import requests
 from django.conf import settings
-
+from django.core.cache import cache
 
 def processor(request):
     context = {
@@ -14,12 +14,17 @@ def processor(request):
     # Only make this request for users authenticated via Ory. 
     # Local users will have the email field set, but not users in Ory
     if request.user.is_authenticated and not request.user.email:
-        r = requests.get(
-            f"{settings.ORY_SDK_URL}/self-service/logout/browser",
-            cookies=request.COOKIES
-        )
+        cache_key = f"logout_{request.COOKIES.get('sessionid')}"
+        logout_url = cache.get(cache_key)
+        if not logout_url:
+            r = requests.get(
+                f"{settings.ORY_SDK_URL}/self-service/logout/browser",
+                cookies=request.COOKIES
+            )
+            logout_url = r.json().get('logout_url')
+            cache.set(cache_key, logout_url, timeout=900) # Cache for 15 minutes
 
-        context["logout_url"] = r.json().get('logout_url')
+        context["logout_url"] = logout_url
 
     return context
 

--- a/django_ory_auth/context.py
+++ b/django_ory_auth/context.py
@@ -1,3 +1,5 @@
+from json import JSONDecodeError
+
 import requests
 from django.conf import settings
 
@@ -17,6 +19,10 @@ def processor(request):
             cookies=request.COOKIES
         )
 
-        context["logout_url"] = r.json().get('logout_url')
+        try:
+            context["logout_url"] = r.json().get('logout_url')
+        except JSONDecodeError:
+            # This will fail for local users, so don't bomb out
+            pass
     return context
 

--- a/django_ory_auth/middleware.py
+++ b/django_ory_auth/middleware.py
@@ -1,10 +1,43 @@
-from django.contrib import auth
+from datetime import datetime, timedelta
 from django.utils.deprecation import MiddlewareMixin
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import SimpleLazyObject
+from django.contrib.auth.models import AnonymousUser
+
+from .apps import config
+from .backend import OryBackend
+
+LAST_AUTH_CHECK_KEY = 'LAST_AUTH_CHECK_KEY'
+
+def get_user(request):
+    must_authenticate_user = True
+
+    if hasattr(request, "_cached_user"):
+        # check if we need to reauthenticate the user again
+        last_auth_check = datetime.fromisoformat(request.session.get(LAST_AUTH_CHECK_KEY, "0001-01-01T00:00:00"))
+        if datetime.now() < last_auth_check + timedelta(seconds=config().get('ORY_AUTH_REFRESH_INTERVAL')):
+            must_authenticate_user = False
+
+    if must_authenticate_user:
+        backend = OryBackend()
+        user = backend.authenticate(request)
+        if user:
+            request._cached_user = user
+            request.session[LAST_AUTH_CHECK_KEY] = datetime.now().isoformat()
+        else:
+            return None
+
+    return request._cached_user
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        user = auth.authenticate(request)
+        if not hasattr(request, "session"):
+            raise ImproperlyConfigured(
+                "The Django Ory authentication middleware requires session "
+                "middleware to be installed. See django ory auth README'."
+            )
+
+        user = SimpleLazyObject(lambda: get_user(request))
         if user:
             request.user = user
-            auth.login(request, user)

--- a/django_ory_auth/urls.py
+++ b/django_ory_auth/urls.py
@@ -1,0 +1,7 @@
+from django.urls import include, path
+
+from .views import logout
+
+urlpatterns = [
+    path("_logout", logout, name="logout_cache"),
+]

--- a/django_ory_auth/urls.py
+++ b/django_ory_auth/urls.py
@@ -1,7 +1,8 @@
 from django.urls import include, path
 
-from .views import logout
+from .views import logout, login
 
 urlpatterns = [
-    path("_logout", logout, name="logout_cache"),
+    path("_login", login, name="ory_login"),
+    path("_logout", logout, name="ory_logout"),
 ]

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,5 +1,6 @@
 from django.core.cache import cache
 from django.shortcuts import redirect
+from django.contrib.auth import logout
 
 def logout(request):
     """
@@ -12,4 +13,4 @@ def logout(request):
     logout_cache_key = f"logout_{request.COOKIES.get('sessionid')}"
     cache.delete(logout_cache_key)
 
-    return redirect('logout')
+    return redirect('/')

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,6 +1,7 @@
 from django.core.cache import cache
 from django.shortcuts import redirect
 from django.contrib.auth import logout
+from django.conf import settings
 
 def logout(request):
     """
@@ -13,4 +14,4 @@ def logout(request):
     logout_cache_key = f"logout_{request.COOKIES.get('sessionid')}"
     cache.delete(logout_cache_key)
 
-    return redirect('/')
+    return redirect(settings.LOGOUT_REDIRECT_URL)

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,3 +1,14 @@
 from django.shortcuts import render
 
-# Create your views here.
+def logout(request):
+    """
+    View that clears cached auth data. Configure Ory to redirect here 
+    on log out.
+    """
+    user_id_cache_key = f"userid_{request.COOKIES.get('sessionid')}"
+    cache.delete(user_id_cache_key)
+  
+    logout_cache_key = f"logout_{request.COOKIES.get('sessionid')}"
+    cache.delete(logout_cache_key)
+
+    return redirect('logout_redirect_url_name')

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,17 +1,28 @@
-from django.core.cache import cache
+from django.contrib.auth import login as contrib_auth_login
 from django.shortcuts import redirect
-from django.contrib.auth import logout
+from django.contrib.auth import logout as contrib_auth_logout
 from django.conf import settings
+
+from .middleware import get_user
+
+def login(request, user, backend=None):
+    """
+    Logs a user in
+    """
+    user = get_user(request)
+    if user is not None:
+        contrib_auth_login(request, user)
+
+    return redirect(settings.LOGIN_REDIRECT_URL)
 
 def logout(request):
     """
-    View that clears cached auth data. Configure Ory to redirect here 
+    View that clears cached auth data. Configure Ory to redirect here
     on log out.
     """
-    user_id_cache_key = f"userid_{request.COOKIES.get('sessionid')}"
-    cache.delete(user_id_cache_key)
-  
-    logout_cache_key = f"logout_{request.COOKIES.get('sessionid')}"
-    cache.delete(logout_cache_key)
+    if hasattr(request, "_cached_user"):
+        delattr(request, "_cached_user")
+
+    contrib_auth_logout(request)
 
     return redirect(settings.LOGOUT_REDIRECT_URL)

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -12,4 +12,4 @@ def logout(request):
     logout_cache_key = f"logout_{request.COOKIES.get('sessionid')}"
     cache.delete(logout_cache_key)
 
-    return redirect('logout_redirect_url_name')
+    return redirect('logout')

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import redirect
 
 def logout(request):
     """

--- a/django_ory_auth/views.py
+++ b/django_ory_auth/views.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.shortcuts import redirect
 
 def logout(request):


### PR DESCRIPTION
This makes the library play nicely with local users. Fallback to local auth (e.g. for admins) can be done with:

```
AUTHENTICATION_BACKENDS = [
    "django_ory_auth.backend.OryBackend",
    "django.contrib.auth.backends.ModelBackend"
]
```